### PR TITLE
Add more docs to cover corner cases and different versions of Kafka

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ You'll need to add the correct `cdap-kafka-pack` library, based on your Kafka cl
 <dependencies>
   ...
   <dependency>
-    <groupId>co.cask.cdap.packs</groupId>
+    <groupId>co.cask.cdap</groupId>
     <artifactId>cdap-kafka-flow-compat-0.8</artifactId>
     <version>0.1.0</version>
   </dependency>
@@ -241,18 +241,19 @@ Be sure you download v0.8.x, as this guide is designed to work specifically with
 Follow the instructions on [Kafka v0.8.x Quickstart](https://kafka.apache.org/08/quickstart.html) to publish messages to `MyTopic`.
 The instructions are repeated below for your convenience and assume you have download the binary distribution. 
 
-```bash
-$ tar xzf kafka-<VERSION>.tgz
-$ cd kafka-<VERSION>
-# Start Zookeeper Server
-$ bin/zookeeper-server-start.sh config/zookeeper.properties
-# Start Kafka Server
-$ bin/kafka-server-start.sh config/server.properties
-# Create a new Kafka topic - MyTopic
-$ bin/kafka-create-topic.sh --zookeeper localhost:2181 --replica 1 --partition 1 --topic MyTopic
-# Send messages on the topic - MyTopic
-$ bin/kafka-console-producer.sh --broker-list localhost:9092 --topic MyTopic
-```
+    $ tar xzf kafka-<VERSION>.tgz
+    $ cd kafka-<VERSION>
+    # Start Zookeeper Server
+    $ bin/zookeeper-server-start.sh config/zookeeper.properties
+    # Start Kafka Server [Ignore any java.net.BindException exception thrown (since there could be port conflict with standalone CDAP's Zookeeper Server)]
+    $ bin/kafka-server-start.sh config/server.properties
+    # Create a new Kafka topic - MyTopic [use the correct arguments based on the script available in the bin directory]
+    $ bin/kafka-create-topic.sh --zookeeper localhost:2181 --replica 1 --partition 1 --topic MyTopic
+    # (OR)
+    $ bin/kafka-topics.sh --create --zookeeper localhost:2181 --topic MyTopic
+    # Send messages on the topic - MyTopic
+    $ bin/kafka-console-producer.sh --broker-list localhost:9092 --topic MyTopic
+
 Once the kafka-console-producer.sh script is invoked, you can type messages on the console and every line is published as a message
 to `MyTopic`. Go ahead and publish a few messages. "CDAP and Kafka, working together!".
 

--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ The instructions are repeated below for your convenience and assume you have dow
     $ bin/kafka-server-start.sh config/server.properties
     # Create a new Kafka topic - MyTopic [use the correct arguments based on the script available in the bin directory]
     $ bin/kafka-create-topic.sh --zookeeper localhost:2181 --replica 1 --partition 1 --topic MyTopic
-    # (OR)
+    (OR)
     $ bin/kafka-topics.sh --create --zookeeper localhost:2181 --topic MyTopic
     # Send messages on the topic - MyTopic
     $ bin/kafka-console-producer.sh --broker-list localhost:9092 --topic MyTopic

--- a/pom.xml
+++ b/pom.xml
@@ -60,10 +60,21 @@
       <version>${kafka.pack.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>log4j-over-slf4j</artifactId>
+      <version>${slf4j.version}</version>
+    </dependency>
+    <dependency>
       <groupId>co.cask.cdap</groupId>
       <artifactId>cdap-unit-test</artifactId>
       <version>${cdap.version}</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-log4j12</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/src/main/java/co/cask/cdap/guides/kafka/Constants.java
+++ b/src/main/java/co/cask/cdap/guides/kafka/Constants.java
@@ -24,8 +24,8 @@ public final class Constants {
   public static final String SERVICE_NAME = "KafkaStatsService";
   public static final String STATS_TABLE_NAME = "kafkaCounter";
   public static final String OFFSET_TABLE_NAME = "kafkaOffsets";
-  public static final String KAFKA_FLOWLET = "kafkaSubFlowlet";
-  public static final String COUNTER_FLOWLET = "countMessages";
+  public static final String KAFKA_FLOWLET = "kafkaConsumer";
+  public static final String COUNTER_FLOWLET = "counterFlowlet";
   public static final String COUNT_KEY = "totalCount";
   public static final String SIZE_KEY = "totalSize";
 


### PR DESCRIPTION
- In some 0.8.x versions of Kafka, there is kafka_create_topic.sh but in other versions, there is kafka-topics.sh script. Covering both cases.
- Starting zookeeper-server on port 2181 (default in config/zookeeper.properties) throws Exception on some machines but doesn't on others. Document that scenario. 
